### PR TITLE
fix: use loadXcmsData() instead of faahKO package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ Suggests:
     BiocParallel,
     MsExperiment,
     msdata,
-    faahKO,
     covr
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/XCMSnExp_CAMERA_peaklist_long.R
+++ b/R/XCMSnExp_CAMERA_peaklist_long.R
@@ -63,10 +63,9 @@
 #' library(xcms)
 #' library(CAMERA)
 #' library(BiocParallel)
-#' library(faahKO)
 #'
 #' # Load example data
-#' data("faahko_sub", package = "faahKO")
+#' faahko_sub <- loadXcmsData("faahko_sub")
 #'
 #' # Peak detection
 #' cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)

--- a/R/chromPeaks_classic.R
+++ b/R/chromPeaks_classic.R
@@ -22,7 +22,7 @@
 #' library(BiocParallel)
 #'
 #' # Load example data
-#' data("faahko_sub", package = "faahKO")
+#' faahko_sub <- loadXcmsData("faahko_sub")
 #'
 #' # Peak detection
 #' cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)

--- a/tests/testthat/test-XCMSnExp_CAMERA_peaklist_long.R
+++ b/tests/testthat/test-XCMSnExp_CAMERA_peaklist_long.R
@@ -2,15 +2,13 @@
 
 test_that("chromPeaks_classic returns a tibble with expected structure", {
   skip_if_not_installed("xcms")
-  skip_if_not_installed("faahKO")
   skip_if_not_installed("BiocParallel")
 
   library(xcms)
   library(BiocParallel)
-  library(faahKO)
 
   # Load example data
-  data("faahko_sub", package = "faahKO")
+  faahko_sub <- loadXcmsData("faahko_sub")
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)
@@ -74,16 +72,16 @@ test_that("chromPeaks_classic works with XcmsExperiment objects", {
 test_that("XCMSnExp_CAMERA_peaklist_long returns expected structure", {
   skip_if_not_installed("xcms")
   skip_if_not_installed("CAMERA")
-  skip_if_not_installed("faahKO")
+  
   skip_if_not_installed("BiocParallel")
 
   library(xcms)
   library(CAMERA)
   library(BiocParallel)
-  library(faahKO)
+  
 
   # Load example data
-  data("faahko_sub", package = "faahKO")
+  faahko_sub <- loadXcmsData("faahko_sub")
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)
@@ -139,17 +137,17 @@ test_that("XCMSnExp_CAMERA_peaklist_long returns expected structure", {
 test_that("XCMSnExp_CAMERA_peaklist_long has one row per feature per sample", {
   skip_if_not_installed("xcms")
   skip_if_not_installed("CAMERA")
-  skip_if_not_installed("faahKO")
+  
   skip_if_not_installed("BiocParallel")
 
   library(xcms)
   library(CAMERA)
   library(BiocParallel)
-  library(faahKO)
+  
   library(dplyr)
 
   # Load example data
-  data("faahko_sub", package = "faahKO")
+  faahko_sub <- loadXcmsData("faahko_sub")
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)
@@ -188,17 +186,17 @@ test_that("XCMSnExp_CAMERA_peaklist_long has one row per feature per sample", {
 test_that("XCMSnExp_CAMERA_peaklist_long handles missing values correctly", {
   skip_if_not_installed("xcms")
   skip_if_not_installed("CAMERA")
-  skip_if_not_installed("faahKO")
+  
   skip_if_not_installed("BiocParallel")
 
   library(xcms)
   library(CAMERA)
   library(BiocParallel)
-  library(faahKO)
+  
   library(dplyr)
 
   # Load example data
-  data("faahko_sub", package = "faahKO")
+  faahko_sub <- loadXcmsData("faahko_sub")
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)
@@ -234,18 +232,18 @@ test_that("XCMSnExp_CAMERA_peaklist_long handles missing values correctly", {
 test_that("XCMSnExp_CAMERA_peaklist_long includes pData information", {
   skip_if_not_installed("xcms")
   skip_if_not_installed("CAMERA")
-  skip_if_not_installed("faahKO")
+  
   skip_if_not_installed("BiocParallel")
   skip_if_not_installed("Biobase")
 
   library(xcms)
   library(CAMERA)
   library(BiocParallel)
-  library(faahKO)
+  
   library(Biobase)
 
   # Load example data
-  data("faahko_sub", package = "faahKO")
+  faahko_sub <- loadXcmsData("faahko_sub")
 
   # Add sample metadata
   pd <- data.frame(
@@ -280,17 +278,17 @@ test_that("XCMSnExp_CAMERA_peaklist_long includes pData information", {
 test_that("XCMSnExp_CAMERA_peaklist_long CAMERA annotations are present", {
   skip_if_not_installed("xcms")
   skip_if_not_installed("CAMERA")
-  skip_if_not_installed("faahKO")
+  
   skip_if_not_installed("BiocParallel")
 
   library(xcms)
   library(CAMERA)
   library(BiocParallel)
-  library(faahKO)
+  
   library(dplyr)
 
   # Load example data
-  data("faahko_sub", package = "faahKO")
+  faahko_sub <- loadXcmsData("faahko_sub")
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)

--- a/vignettes/long-format-peaklist.Rmd
+++ b/vignettes/long-format-peaklist.Rmd
@@ -8,15 +8,9 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
-# Check if required packages are available for vignette evaluation
-can_eval <- requireNamespace("faahKO", quietly = TRUE) &&
-            requireNamespace("CAMERA", quietly = TRUE) &&
-            requireNamespace("BiocParallel", quietly = TRUE)
-
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>",
-  eval = can_eval
+  comment = "#>"
 )
 ```
 
@@ -35,18 +29,6 @@ that integrates:
 The resulting long-format table has one row per feature per sample, making it
 ideal for downstream analysis with tidyverse tools like `dplyr` and `ggplot2`.
 
-```{r check_packages, echo=FALSE, results='asis', eval=TRUE}
-if (!can_eval) {
-  cat("**Note:** This vignette requires the `faahKO`, `CAMERA`, and `BiocParallel` packages to run the examples. Install these packages to execute the code:\n\n")
-  cat("```r\n")
-  cat("if (!requireNamespace(\"BiocManager\", quietly = TRUE))\n")
-  cat("    install.packages(\"BiocManager\")\n")
-  cat("BiocManager::install(c(\"faahKO\", \"CAMERA\", \"BiocParallel\"))\n")
-  cat("```\n\n")
-  cat("The code is shown below but not evaluated in this build.\n\n")
-}
-```
-
 # Setup
 
 ```{r setup, message=FALSE}
@@ -62,12 +44,12 @@ library(ggplot2)
 
 ## Load Example Data
 
-We'll use the `faahKO` dataset that comes with the `faahKO` package. This
-contains LC-MS data from wild-type and knockout samples.
+We'll use the `faahko_sub` dataset from XCMS, which contains LC-MS data from
+wild-type and knockout samples.
 
 ```{r load_data, message=FALSE}
-library(faahKO)
-data("faahko_sub", package = "faahKO")
+# Load example data from XCMS
+faahko_sub <- loadXcmsData("faahko_sub")
 
 # Check the files
 fileNames(faahko_sub)


### PR DESCRIPTION
Replace all references to data loading from the faahKO package with loadXcmsData('faahko_sub') which is available directly from xcms. This resolves vignette build failures and simplifies dependencies.

Changes:
- Updated vignette to use loadXcmsData()
- Updated all function examples to use loadXcmsData()
- Updated all tests to use loadXcmsData()
- Removed faahKO from DESCRIPTION Suggests
- Removed conditional evaluation logic (no longer needed)

The faahko_sub dataset is available through xcms::loadXcmsData(), so there's no need for the separate faahKO package dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)