### PR TITLE
fix: ensure CAMERA annotation columns always exist in output

### DIFF
--- a/vignettes/long-format-peaklist.Rmd
+++ b/vignettes/long-format-peaklist.Rmd
@@ -130,11 +130,11 @@ dim(peak_table_no_camera)
 # View first few rows
 head(peak_table_no_camera)
 
-# Check column names - note that isotopes, adduct, and pcgroup are not present
+# Check column names - note that isotopes, adduct, and pcgroup are present but filled with NA
 colnames(peak_table_no_camera)
 ```
 
-The resulting table contains all feature and peak information, but the CAMERA annotation columns (`isotopes`, `adduct`, `pcgroup`) are not included.
+The resulting table contains all feature and peak information. The CAMERA annotation columns (`isotopes`, `adduct`, `pcgroup`) are present but filled with NA values since no CAMERA annotations were provided.
 
 ## CAMERA Annotation (Optional)
 


### PR DESCRIPTION
When XCMSnExp_CAMERA_peaklist_long() is called without xsAnnotate parameter, the function now creates isotopes, adduct, and pcgroup columns filled with NA values. This prevents "column doesn't exist" errors in the vignette and downstream code.

Changes:
- Add else clause to create NA columns when xsAnnotate is NULL
- Update function documentation to reflect new behavior
- Update vignette text to match new behavior
- Use any_of() for safer column selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)