### PR TITLE
fix: resolve XcmsExperiment compatibility and CAMERA column issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,9 +18,7 @@ Imports:
     xcms (>= 3.18.0),
     dplyr,
     tidyr,
-    purrr,
     tibble,
-    methods,
     Biobase
 Suggests:
     CAMERA,
@@ -30,6 +28,7 @@ Suggests:
     BiocParallel,
     MsExperiment,
     msdata,
+    ggplot2,
     covr
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,29 @@
+#' @importFrom utils globalVariables
+#' @keywords internal
+utils::globalVariables(c(
+  ".",
+  "adduct",
+  "f_mzmax",
+  "f_mzmed",
+  "f_mzmin",
+  "f_rtmax",
+  "f_rtmed",
+  "f_rtmin",
+  "feature_id",
+  "filename",
+  "filepath",
+  "fromFile",
+  "into",
+  "into_f",
+  "isotopes",
+  "ms_level",
+  "mzmax",
+  "mzmed",
+  "mzmin",
+  "n",
+  "pcgroup",
+  "peakidx",
+  "rtmax",
+  "rtmed",
+  "rtmin"
+))

--- a/tests/testthat/test-XCMSnExp_CAMERA_peaklist_long.R
+++ b/tests/testthat/test-XCMSnExp_CAMERA_peaklist_long.R
@@ -92,14 +92,17 @@ test_that("XCMSnExp_CAMERA_peaklist_long returns expected structure", {
                           minFraction = 0.5)
   xdata <- groupChromPeaks(xdata, param = pdp)
 
+  # Convert to xcmsSet for CAMERA (CAMERA requires the old xcmsSet class)
+  xset <- as(xdata, "xcmsSet")
+
   # CAMERA annotation
-  xs <- xsAnnotate(xdata)
+  xs <- xsAnnotate(xset)
   xs <- groupFWHM(xs)
   xs <- findIsotopes(xs)
   xs <- groupCorr(xs)
   xs <- findAdducts(xs)
 
-  # Create long-format peak table
+  # Create long-format peak table (pass XCMSnExp object, not xcmsSet)
   peak_table <- XCMSnExp_CAMERA_peaklist_long(xdata, xs)
 
   # Check it's a tibble
@@ -158,12 +161,15 @@ test_that("XCMSnExp_CAMERA_peaklist_long has one row per feature per sample", {
                           minFraction = 0.5)
   xdata <- groupChromPeaks(xdata, param = pdp)
 
+  # Convert to xcmsSet for CAMERA (CAMERA requires the old xcmsSet class)
+  xset <- as(xdata, "xcmsSet")
+
   # CAMERA annotation
-  xs <- xsAnnotate(xdata)
+  xs <- xsAnnotate(xset)
   xs <- groupFWHM(xs)
   xs <- findIsotopes(xs)
 
-  # Create long-format peak table
+  # Create long-format peak table (pass XCMSnExp object, not xcmsSet)
   peak_table <- XCMSnExp_CAMERA_peaklist_long(xdata, xs)
 
   # Get number of features and samples
@@ -207,11 +213,14 @@ test_that("XCMSnExp_CAMERA_peaklist_long handles missing values correctly", {
                           minFraction = 0.3)
   xdata <- groupChromPeaks(xdata, param = pdp)
 
+  # Convert to xcmsSet for CAMERA (CAMERA requires the old xcmsSet class)
+  xset <- as(xdata, "xcmsSet")
+
   # CAMERA annotation
-  xs <- xsAnnotate(xdata)
+  xs <- xsAnnotate(xset)
   xs <- groupFWHM(xs)
 
-  # Create long-format peak table
+  # Create long-format peak table (pass XCMSnExp object, not xcmsSet)
   peak_table <- XCMSnExp_CAMERA_peaklist_long(xdata, xs)
 
   # Check that we have some NA values in intensity columns
@@ -262,11 +271,14 @@ test_that("XCMSnExp_CAMERA_peaklist_long includes pData information", {
                           minFraction = 0.5)
   xdata <- groupChromPeaks(xdata, param = pdp)
 
+  # Convert to xcmsSet for CAMERA (CAMERA requires the old xcmsSet class)
+  xset <- as(xdata, "xcmsSet")
+
   # CAMERA annotation
-  xs <- xsAnnotate(xdata)
+  xs <- xsAnnotate(xset)
   xs <- groupFWHM(xs)
 
-  # Create long-format peak table
+  # Create long-format peak table (pass XCMSnExp object, not xcmsSet)
   peak_table <- XCMSnExp_CAMERA_peaklist_long(xdata, xs)
 
   # Check that pData columns are present
@@ -299,14 +311,17 @@ test_that("XCMSnExp_CAMERA_peaklist_long CAMERA annotations are present", {
                           minFraction = 0.5)
   xdata <- groupChromPeaks(xdata, param = pdp)
 
+  # Convert to xcmsSet for CAMERA (CAMERA requires the old xcmsSet class)
+  xset <- as(xdata, "xcmsSet")
+
   # CAMERA annotation with all steps
-  xs <- xsAnnotate(xdata)
+  xs <- xsAnnotate(xset)
   xs <- groupFWHM(xs)
   xs <- findIsotopes(xs)
   xs <- groupCorr(xs)
   xs <- findAdducts(xs)
 
-  # Create long-format peak table
+  # Create long-format peak table (pass XCMSnExp object, not xcmsSet)
   peak_table <- XCMSnExp_CAMERA_peaklist_long(xdata, xs)
 
   # Check that CAMERA annotations are present

--- a/vignettes/long-format-peaklist.Rmd
+++ b/vignettes/long-format-peaklist.Rmd
@@ -130,11 +130,11 @@ dim(peak_table_no_camera)
 # View first few rows
 head(peak_table_no_camera)
 
-# Check column names - note that isotopes, adduct, and pcgroup are present but filled with NA
+# Check column names - note that isotopes, adduct, and pcgroup are NOT present
 colnames(peak_table_no_camera)
 ```
 
-The resulting table contains all feature and peak information. The CAMERA annotation columns (`isotopes`, `adduct`, `pcgroup`) are present but filled with NA values since no CAMERA annotations were provided.
+The resulting table contains all feature and peak information. The CAMERA annotation columns (`isotopes`, `adduct`, `pcgroup`) are **not included** when no CAMERA annotations are provided, keeping the output cleaner and more memory-efficient.
 
 ## CAMERA Annotation (Optional)
 


### PR DESCRIPTION
- Add support for XcmsExperiment objects using sampleData() instead of pData()
- Fix CAMERA column behavior: only include isotopes, adduct, pcgroup when xsAnnotate is provided
- Update tests to convert XCMSnExp to xcmsSet for CAMERA compatibility
- Add utils.R with globalVariables to resolve R CMD check NOTEs
- Update documentation and vignette to reflect correct CAMERA usage
- Clean up DESCRIPTION: remove unused imports (purrr, methods), add ggplot2 to Suggests

🤖 Generated with [Claude Code](https://claude.com/claude-code)