### PR TITLE
fix: correct sampleData import from MsExperiment package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,14 +19,14 @@ Imports:
     dplyr,
     tidyr,
     tibble,
-    Biobase
+    Biobase,
+    MsExperiment
 Suggests:
     CAMERA,
     testthat (>= 3.0.0),
     knitr,
     rmarkdown,
     BiocParallel,
-    MsExperiment,
     msdata,
     ggplot2,
     covr

--- a/R/XCMSnExp_CAMERA_peaklist_long.R
+++ b/R/XCMSnExp_CAMERA_peaklist_long.R
@@ -135,7 +135,8 @@
 #' head(peak_table_exp)
 #' }
 #'
-#' @importFrom xcms chromPeaks chromPeakData featureDefinitions featureValues fileNames sampleData
+#' @importFrom xcms chromPeaks chromPeakData featureDefinitions featureValues fileNames
+#' @importFrom MsExperiment sampleData
 #' @importFrom dplyr %>% mutate rename left_join right_join filter group_by
 #'   ungroup slice select rename_with any_of bind_cols as_tibble
 #' @importFrom tidyr unnest gather complete nesting


### PR DESCRIPTION
The @importFrom directive was incorrectly trying to import sampleData from xcms, but it actually comes from MsExperiment. This was causing a roxygen2 warning about an unknown export.

Changes:
- Import sampleData from MsExperiment instead of xcms
- Move MsExperiment from Suggests to Imports in DESCRIPTION

🤖 Generated with [Claude Code](https://claude.com/claude-code)