### PR TITLE
fix: resolve devtools::check() test failures with loadXcmsData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,8 @@ Suggests:
     BiocParallel,
     msdata,
     ggplot2,
-    covr
+    covr,
+    faahKO
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 biocViews: Metabolomics, MassSpectrometry, DataImport

--- a/tests/testthat/helper-data.R
+++ b/tests/testthat/helper-data.R
@@ -1,0 +1,43 @@
+# Helper file to create test data for testthat tests
+# This file is automatically loaded before tests run
+
+library(xcms)
+library(BiocParallel)
+
+# Load faahko_sub test data
+# This loads the pre-processed data object from xcms package
+# and manually fixes file paths to avoid loadXcmsData() issues during R CMD check
+create_faahko_sub <- function() {
+  # Load the data object from xcms package
+  # This is a pre-processed XCMSnExp object with detected peaks
+  e <- new.env()
+  data("faahko_sub", envir = e, package = "xcms")
+  obj <- get("faahko_sub", e)
+
+  # Get the actual file paths from faahKO package
+  cdf_path <- system.file("cdf/KO", package = "faahKO")
+
+  # Check if package is available
+  if (cdf_path == "") {
+    stop("Package 'faahKO' not available. Please install using BiocManager::install('faahKO')")
+  }
+
+  # Get the files that match the basenames in the object
+  file_basenames <- basename(fileNames(obj))
+  files <- file.path(cdf_path, file_basenames)
+
+  # Verify files exist
+  if (!all(file.exists(files))) {
+    stop("Some CDF files not found: ", paste(files[!file.exists(files)], collapse = ", "))
+  }
+
+  # Update file paths in the object using fromFile slot
+  # This avoids the problematic dirname<- approach used by loadXcmsData
+  obj@processingData@files <- files
+
+  return(obj)
+}
+
+# Create the test data object
+# This will be available to all tests
+faahko_sub <- create_faahko_sub()

--- a/tests/testthat/test-XCMSnExp_CAMERA_peaklist_long.R
+++ b/tests/testthat/test-XCMSnExp_CAMERA_peaklist_long.R
@@ -63,8 +63,7 @@ test_that("XCMSnExp_CAMERA_peaklist_long returns expected structure", {
   library(CAMERA)
   library(BiocParallel)
 
-  # Load example data
-  faahko_sub <- loadXcmsData("faahko_sub")
+  # faahko_sub is loaded by helper-data.R
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)
@@ -127,8 +126,7 @@ test_that("XCMSnExp_CAMERA_peaklist_long has one row per feature per sample", {
   library(BiocParallel)
   library(dplyr)
 
-  # Load example data
-  faahko_sub <- loadXcmsData("faahko_sub")
+  # faahko_sub is loaded by helper-data.R
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)
@@ -175,8 +173,7 @@ test_that("XCMSnExp_CAMERA_peaklist_long handles missing values correctly", {
   library(BiocParallel)
   library(dplyr)
 
-  # Load example data
-  faahko_sub <- loadXcmsData("faahko_sub")
+  # faahko_sub is loaded by helper-data.R
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)
@@ -219,8 +216,7 @@ test_that("XCMSnExp_CAMERA_peaklist_long includes pData information", {
   library(BiocParallel)
   library(Biobase)
 
-  # Load example data
-  faahko_sub <- loadXcmsData("faahko_sub")
+  # faahko_sub is loaded by helper-data.R
 
   # Add sample metadata
   pd <- data.frame(
@@ -262,8 +258,7 @@ test_that("XCMSnExp_CAMERA_peaklist_long CAMERA annotations are present", {
   library(BiocParallel)
   library(dplyr)
 
-  # Load example data
-  faahko_sub <- loadXcmsData("faahko_sub")
+  # faahko_sub is loaded by helper-data.R
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)
@@ -312,8 +307,7 @@ test_that("XCMSnExp_CAMERA_peaklist_long works without CAMERA annotations", {
   library(xcms)
   library(BiocParallel)
 
-  # Load example data
-  faahko_sub <- loadXcmsData("faahko_sub")
+  # faahko_sub is loaded by helper-data.R
 
   # Peak detection
   cwp <- CentWaveParam(peakwidth = c(20, 80), noise = 5000)


### PR DESCRIPTION
The tests were failing during R CMD check because loadXcmsData() uses dirname<- which validates file paths more strictly in the check environment.

Changes:
- Created tests/testthat/helper-data.R to load faahko_sub data properly
- Replaced all loadXcmsData("faahko_sub") calls with helper-loaded data
- Updated file paths directly via @processingData@files slot instead of dirname<-
- Added faahKO to DESCRIPTION Suggests since it's used in tests

This fixes the "files do not exist" errors that occurred during check but not during devtools::test().

🤖 Generated with [Claude Code](https://claude.com/claude-code)