### PR TITLE
fix: ensure package version stays below 1.0.0 for Bioconductor

### DIFF
--- a/.github/prepare-news.sh
+++ b/.github/prepare-news.sh
@@ -44,5 +44,9 @@ sed -i 's/(\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\))$/ (\1)/' NEWS.md
 sed -i 's/### /### /' NEWS.md
 sed -i 's/\[compare\/v[0-9].*//' NEWS.md
 
+# Replace version numbers in NEWS.md with BIOC_VERSION
+# This ensures all version references use the 0.99.x format
+sed -i "s/## Changes in v[0-9]\+\.[0-9]\+\.[0-9]\+/## Changes in v$NEXT_VERSION/" NEWS.md
+
 # Update DESCRIPTION version
 sed -i "s/^Version: .*/Version: $NEXT_VERSION/" DESCRIPTION

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## Changes in v1.0.0
+## Changes in v0.99.1
 
 
 ### Bug Fixes


### PR DESCRIPTION
- Updated NEWS.md from v1.0.0 to v0.99.1 to match DESCRIPTION
- Enhanced prepare-news.sh to replace version numbers in NEWS.md content
- Ensures all version references use 0.99.x format for Bioconductor submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)