### PR TITLE
fix: add GitHub remote for commonMZ package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,8 @@ Suggests:
     ggplot2,
     covr,
     faahKO
+Remotes:
+    stanstrup/commonMZ
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 biocViews: Metabolomics, MassSpectrometry, DataImport


### PR DESCRIPTION
The pkgdown GitHub Actions workflow was failing because it couldn't find the commonMZ package. Added Remotes field to DESCRIPTION to specify that commonMZ should be installed from stanstrup/commonMZ on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)