### PR TITLE
fix: resolve NEWS.md duplicate versions and sync with GitHub releases

### DIFF
--- a/.github/prepare-news.sh
+++ b/.github/prepare-news.sh
@@ -34,6 +34,9 @@ fi
 echo "Preparing NEWS.md and DESCRIPTION for version $BIOC_VERSION (from semantic-release: $NEXT_VERSION)..."
 NEXT_VERSION="$BIOC_VERSION"
 
+# Export for potential use by other scripts
+echo "$BIOC_VERSION" > .bioc_version
+
 # Format NEWS.md for R/pkgdown
 sed -i 's/^# \[\([0-9]\+\.[0-9]\+\.[0-9]\+\)\].*/## Changes in v\1/' NEWS.md
 sed -i 's/^## \[\([0-9]\+\.[0-9]\+\.[0-9]\+\)\].*/## Changes in v\1/' NEWS.md
@@ -44,9 +47,9 @@ sed -i 's/(\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\))$/ (\1)/' NEWS.md
 sed -i 's/### /### /' NEWS.md
 sed -i 's/\[compare\/v[0-9].*//' NEWS.md
 
-# Replace version numbers in NEWS.md with BIOC_VERSION
-# This ensures all version references use the 0.99.x format
-sed -i "s/## Changes in v[0-9]\+\.[0-9]\+\.[0-9]\+/## Changes in v$NEXT_VERSION/" NEWS.md
+# Replace ONLY the first (most recent) version number in NEWS.md with BIOC_VERSION
+# This ensures the latest release uses 0.99.x format without touching historical entries
+sed -i "0,/## Changes in v[0-9]\+\.[0-9]\+\.[0-9]\+/{s/## Changes in v[0-9]\+\.[0-9]\+\.[0-9]\+/## Changes in v$NEXT_VERSION/}" NEWS.md
 
 # Update DESCRIPTION version
 sed -i "s/^Version: .*/Version: $NEXT_VERSION/" DESCRIPTION

--- a/.github/sync-bioc-tag.sh
+++ b/.github/sync-bioc-tag.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# sync-bioc-tag.sh - Create and sync 0.99.x tag with GitHub release
+set -e
+
+# Read the Bioconductor version that was set by prepare-news.sh
+if [ -f ".bioc_version" ]; then
+  BIOC_VERSION=$(cat .bioc_version)
+  echo "Syncing Bioconductor version tag: $BIOC_VERSION"
+
+  # Create lightweight tag for the Bioconductor version
+  # This will be picked up by the GitHub release
+  git tag -f "$BIOC_VERSION"
+
+  echo "Created tag $BIOC_VERSION"
+else
+  echo "WARNING: .bioc_version file not found, skipping tag sync"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Thumbs.db
 # Node modules for semantic-release
 node_modules/
 package-lock.json
+.bioc_version

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,5 @@
 {
   "branches": ["main", "master"],
-  "tagFormat": "${version}",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",
@@ -28,8 +27,14 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["NEWS.md", "DESCRIPTION"],
+        "assets": ["NEWS.md", "DESCRIPTION", ".bioc_version"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "successCmd": "./.github/sync-bioc-tag.sh"
       }
     ],
     "@semantic-release/github"

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 
 * replace non-existent fileNames<- with proper dataOrigin replacement ([3995b38](https://github.com/stanstrup/tidyXCMS/commit/3995b38641c161957872d9ad48a80e57f2dbeec6))
 
-## Changes in v0.99.7
+## Changes in v0.99.6
 
 
 ### Bug Fixes
@@ -13,35 +13,35 @@
 * add explicit MSnbase library call in vignette ([6f3c6fb](https://github.com/stanstrup/tidyXCMS/commit/6f3c6fb708ba67c24b893dc71f9b92b9cf0a1f59))
 * add explicit namespace references for fileNames in vignette ([7d1e9f9](https://github.com/stanstrup/tidyXCMS/commit/7d1e9f99f6188f790f73561434b9417e7bbd0868))
 
-## Changes in v0.99.7
+## Changes in v0.99.5
 
 
 ### Bug Fixes
 
 * add GitHub remote for commonMZ package ([5401ce0](https://github.com/stanstrup/tidyXCMS/commit/5401ce0d4f70441f14051b9bf6a146795dc0a116))
 
-## Changes in v0.99.7
+## Changes in v0.99.4
 
 
 ### Features
 
 * integrate commonMZ for CAMERA adduct/fragment rules ([ababed5](https://github.com/stanstrup/tidyXCMS/commit/ababed546a07201cc0782c72bcecc03d163400b8))
 
-## Changes in v0.99.7
+## Changes in v0.99.3
 
 
 ### Bug Fixes
 
 * correct xdata file paths to use system-specific location ([8d60f1a](https://github.com/stanstrup/tidyXCMS/commit/8d60f1ab93fb37b09579cb34157425e51f942dc4))
 
-## Changes in v0.99.7
+## Changes in v0.99.2
 
 
 ### Bug Fixes
 
 * ensure package version stays below 1.0.0 for Bioconductor ([b1bc012](https://github.com/stanstrup/tidyXCMS/commit/b1bc012de886220414ab6302bd3ecafbef71eade))
 
-## Changes in v0.99.7
+## Changes in v0.99.1
 
 
 ### Bug Fixes


### PR DESCRIPTION
- Fix prepare-news.sh to only update the first (most recent) version header instead of all versions
- Reconstruct NEWS.md with correct incremental versions (0.99.1 through 0.99.7)
- Add sync-bioc-tag.sh to create proper 0.99.x tags for GitHub releases
- Ensure future releases stay synchronized at 0.99.x across all systems

This ensures that:
1. NEWS.md shows proper version progression without duplicates
2. DESCRIPTION stays at current 0.99.x version
3. GitHub releases will use 0.99.x tags instead of 1.x.x tags
4. All version references remain consistent for Bioconductor compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)