### PR TITLE
fix: use list.files with recursive search for CDF path matching

### DIFF
--- a/vignettes/long-format-peaklist.Rmd
+++ b/vignettes/long-format-peaklist.Rmd
@@ -85,21 +85,21 @@ The example data contains file paths from the original system. We need to update
 # Get the correct base path for faahKO package on this system
 cdf_path <- file.path(find.package("faahKO"), "cdf")
 
+# Find all CDF files recursively in the cdf_path directory
+real_paths <- list.files(cdf_path, recursive = TRUE, full.names = TRUE)
+
 # Create a mapping table using basenames for safe matching
-path_mapping <- tibble(old_path = unique(spectra(xdata)$dataOrigin)) %>%
-                    mutate(
-                            basename_file = basename(old_path),
-                            new_path = file.path(cdf_path, basename_file)
-                    ) %>% 
-                    select(basename_file, new_path)
+path_mapping <- tibble(
+  real_path = real_paths,
+  basename_file = basename(real_paths)
+)
 
 # Join with spectra dataOrigin by basename and replace
 spectra_df <- tibble(dataOrigin = spectra(xdata)$dataOrigin) %>%
-                mutate(basename_file = basename(dataOrigin)) %>%
-                left_join(path_mapping,
-                         by = "basename_file")
+  mutate(basename_file = basename(dataOrigin)) %>%
+  left_join(path_mapping, by = "basename_file")
 
-spectra(xdata)$dataOrigin <- spectra_df$new_path
+spectra(xdata)$dataOrigin <- spectra_df$real_path
 ```
 
 ## Creating a Basic Long-Format Peak Table


### PR DESCRIPTION
Use list.files(cdf_path, recursive = TRUE, full.names = TRUE) to find actual file paths instead of constructing them manually, properly handling files in subfolders. Match by basename to map old paths to new paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)