### PR TITLE
refactor: use coercion and dropChromPeaks for cleaner test setup

### DIFF
--- a/tests/testthat/test-tidy_peaklist.R
+++ b/tests/testthat/test-tidy_peaklist.R
@@ -494,15 +494,12 @@ test_that("tidy_peaklist errors when no peaks are found", {
   library(BiocParallel)
   library(msdata)
 
-  # Create an XcmsExperiment object with findChromPeaks but no peaks detected
-  # Use extremely restrictive parameters to ensure no peaks are found
+  # Create an XcmsExperiment object without peaks
+  # Coerce MsExperiment to XcmsExperiment and drop any peaks
   fls <- dir(system.file("sciex", package = "msdata"), full.names = TRUE)
   xdata_no_peaks <- readMsExperiment(spectraFiles = fls[1], BPPARAM = SerialParam())
-
-  # Run findChromPeaks with parameters that won't find any peaks
-  # (very high noise threshold ensures no peaks are detected)
-  cwp <- CentWaveParam(peakwidth = c(5, 20), noise = 1e10)
-  xdata_no_peaks <- findChromPeaks(xdata_no_peaks, param = cwp, BPPARAM = SerialParam())
+  xdata_no_peaks <- as(xdata_no_peaks, "XcmsExperiment")
+  xdata_no_peaks <- dropChromPeaks(xdata_no_peaks)
 
   # Should error because no peaks have been detected
   expect_error(


### PR DESCRIPTION
Replace findChromPeaks with extreme parameters (noise = 1e10) with a cleaner approach: coerce MsExperiment to XcmsExperiment and explicitly drop peaks using dropChromPeaks(). This is more explicit and maintainable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)